### PR TITLE
Fri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde-wasm-bindgen = { version = "0.6.1", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 # I think we need to mention this for secp256k1-sys to work
 getrandom = { versioin = "0.2", optional = true }
+hex = "0.4.3"
 
 [patch.crates-io.base58check]
 git = "https://github.com/rust-bitcoin/rust-bitcoin"

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -13,7 +13,7 @@ pub enum StackEntry {
 }
 
 #[derive(Clone, Eq, Debug, PartialEq)]
-pub struct Stack(Vec<StackEntry>);
+pub struct Stack(pub Vec<StackEntry>);
 
 impl Stack {
     pub fn new() -> Self {


### PR DESCRIPTION
Add a logger for bitcoin script exec
Logger will print log when all the following conditions meet
a: debug mode which means logger is disabled in release mode.
b: an error occurs

Logger will print the  last 5 logs before error occors.

Step:  num ops executed
stacks: the stack and alt stack before the op applied
curr_op: op to be applied
after_stack: the stack after the curr_op applied.

